### PR TITLE
Clarify reset password verifying message

### DIFF
--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -84,7 +84,7 @@ export default function ResetPassword() {
       <h1 style={{ color: "#1F4142", marginBottom: "1rem" }}>Reset Your Password</h1>
 
       {/* Show loading if verifying */}
-      {status === "verifying" && <p>Setting...</p>}
+      {status === "verifying" && <p>Verifying...</p>}
 
       {/* Show form only if ready */}
       {status === "ready" && (


### PR DESCRIPTION
## Summary
- use clearer "Verifying..." text while confirming password reset

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68a74f453fb88324903009d24080d4e1