### PR TITLE
Add Jest test for sendWelcomeEmail and remove live send script

### DIFF
--- a/axios-demo/lib/sendBrandedEmail.test.js
+++ b/axios-demo/lib/sendBrandedEmail.test.js
@@ -1,0 +1,31 @@
+const axios = require('axios');
+const sendWelcomeEmail = require('./sendBrandedEmail');
+
+jest.mock('axios');
+
+describe('sendWelcomeEmail', () => {
+  it('calls axios.post with the expected payload', async () => {
+    process.env.BREVO_API_KEY = 'test-api-key';
+    axios.post.mockResolvedValue({ data: {} });
+
+    const toEmail = 'dummy@example.com';
+    const firstName = 'Dummy';
+
+    await sendWelcomeEmail(toEmail, firstName);
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://api.brevo.com/v3/smtp/email',
+      expect.objectContaining({
+        sender: { name: 'The Clear Path', email: 'noreply@theclearpath.ae' },
+        to: [{ email: toEmail, name: firstName }],
+        subject: 'Welcome to The Clear Path!',
+      }),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'api-key': 'test-api-key',
+          'Content-Type': 'application/json',
+        }),
+      })
+    );
+  });
+});

--- a/axios-demo/lib/test-send.js
+++ b/axios-demo/lib/test-send.js
@@ -1,5 +1,0 @@
-require('dotenv').config({ path: '../../.env' }); // <-- add this at the very top
-
-const sendWelcomeEmail = require('./sendBrandedEmail');
-
-sendWelcomeEmail('rohaelnaeem1995@gmail.com', 'Rohael');


### PR DESCRIPTION
## Summary
- add unit test to ensure `sendWelcomeEmail` posts expected payload
- remove `test-send.js` to prevent accidental live emails

## Testing
- `npx jest axios-demo/lib/sendBrandedEmail.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a752cbbddc83248b0733197e021449