### PR TITLE
Use API route for signup verification

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -9,7 +9,6 @@ import { auth } from '@/firebaseClient';
 import {
   createUserWithEmailAndPassword,
   updateProfile,
-  sendEmailVerification,
   getRedirectResult,
   onAuthStateChanged,
   GoogleAuthProvider,
@@ -95,14 +94,15 @@ export default function Signup(): React.ReactElement {
       const trimmedName = name.trim();
       if (trimmedName) await updateProfile(user, { displayName: trimmedName });
 
-      await sendEmailVerification(user, {
-        url: 'https://portal.theclearpath.ae/verify-email',
-        handleCodeInApp: true,
+      await fetch('/api/send-verification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, displayName: trimmedName })
       });
 
       setSuccess('Account created. Check your email to verify.');
       // Stay signed in; verify page will push to /portal after applyActionCode
-      setTimeout(() => router.push('/verify-email/sent'), 1200);
+      router.push('/verify-email/sent');
     } catch (e: unknown) {
       const msg = errMsg(e);
       if (msg.includes('auth/email-already-in-use')) {


### PR DESCRIPTION
## Summary
- replace Firebase `sendEmailVerification` with POST `/api/send-verification`
- await request before redirecting to verification page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any types in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a753326ec883248d8237f28628cf15