### PR TITLE
Check welcomeSent before sending welcome email

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,9 @@
 require('dotenv').config();
 const functions = require('firebase-functions');
 const axios = require('axios');
+const admin = require('firebase-admin');
+
+admin.initializeApp();
 
 const BREVO_TEMPLATE_ID = 1;
 const sender = {
@@ -15,6 +18,29 @@ exports.sendWelcomeEmail = functions.auth.user().onCreate(async (user) => {
     (user.email ? user.email.split('@')[0] : 'there');
   const email = user.email;
   if (!email) return null;
+
+  let welcomeSent = false;
+  let userRecord;
+  try {
+    userRecord = await admin.auth().getUser(user.uid);
+    welcomeSent = userRecord.customClaims?.welcomeSent;
+  } catch (err) {
+    console.error('Error fetching user claims:', err.message);
+  }
+
+  if (!welcomeSent) {
+    try {
+      const doc = await admin.firestore().collection('users').doc(user.uid).get();
+      welcomeSent = doc.exists && doc.data().welcomeSent;
+    } catch (err) {
+      console.error('Error checking Firestore for welcomeSent:', err.message);
+    }
+  }
+
+  if (welcomeSent) {
+    console.log(`⚠️ Welcome email already sent to ${email}`);
+    return null;
+  }
 
   const payload = {
     to: [{ email, name: firstName }],
@@ -35,6 +61,17 @@ exports.sendWelcomeEmail = functions.auth.user().onCreate(async (user) => {
       }
     );
     console.log(`✅ Welcome email sent to ${email}`);
+    await Promise.all([
+      admin.auth().setCustomUserClaims(user.uid, {
+        ...(userRecord?.customClaims || {}),
+        welcomeSent: true,
+      }),
+      admin
+        .firestore()
+        .collection('users')
+        .doc(user.uid)
+        .set({ welcomeSent: true }, { merge: true }),
+    ]);
   } catch (error) {
     const response = error.response?.data || error.message;
     console.error(`❌ Failed to send email to ${email}:`, response);


### PR DESCRIPTION
## Summary
- Ensure Firebase function checks Firestore/custom claims for `welcomeSent` before emailing
- Mark `welcomeSent` in both custom claims and Firestore after email

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_68a7533384488324ac38cf1dec074643