### PR TITLE
Send welcome email after Google sign-in

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { signInWithEmailAndPassword, getRedirectResult, onAuthStateChanged } from 'firebase/auth';
 import { auth } from '@/firebaseClient';
+import { sendWelcome } from '@/sendWelcome';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -18,7 +19,12 @@ export default function LoginPage(): React.ReactElement {
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, (u) => { if (u) router.replace('/portal'); });
     getRedirectResult(auth)
-      .then((res) => { if (res?.user) router.replace('/portal'); })
+      .then(async (res) => {
+        if (res?.user) {
+          await sendWelcome(res.user.email, res.user.displayName || undefined);
+          router.replace('/portal');
+        }
+      })
       .catch(() => { });
     return () => unsub();
   }, [router]);

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -19,6 +19,7 @@ import {
   browserLocalPersistence,
   type UserCredential,
 } from 'firebase/auth';
+import { sendWelcome } from '@/sendWelcome';
 
 function errMsg(e: unknown): string {
   if (e instanceof Error) return e.message;
@@ -48,7 +49,12 @@ export default function Signup(): React.ReactElement {
 
     // Complete Google redirect flow
     getRedirectResult(auth)
-      .then((res: UserCredential | null) => { if (res?.user) router.replace('/portal'); })
+      .then(async (res: UserCredential | null) => {
+        if (res?.user) {
+          await sendWelcome(res.user.email, res.user.displayName || undefined);
+          router.replace('/portal');
+        }
+      })
       .catch(() => { });
 
     return () => unsub();
@@ -65,7 +71,8 @@ export default function Signup(): React.ReactElement {
       provider.setCustomParameters({ prompt: 'select_account' });
 
       try {
-        await signInWithPopup(auth, provider);
+        const res = await signInWithPopup(auth, provider);
+        await sendWelcome(res.user.email, res.user.displayName || undefined);
         router.replace('/portal');
       } catch (err: any) {
         const code = err?.code ?? '';

--- a/src/sendWelcome.ts
+++ b/src/sendWelcome.ts
@@ -1,0 +1,19 @@
+export async function sendWelcome(email?: string | null, displayName?: string | null): Promise<void> {
+  const e = (email || '').trim();
+  if (!e) return;
+  const key = `welcome-sent:${e}`;
+  try {
+    if (typeof window !== 'undefined' && localStorage.getItem(key)) return;
+    await fetch('/api/send-welcome', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Idempotency-Key': key,
+      },
+      body: JSON.stringify({ email: e, displayName: displayName || undefined }),
+    });
+    if (typeof window !== 'undefined') localStorage.setItem(key, '1');
+  } catch {
+    // ignore errors
+  }
+}


### PR DESCRIPTION
## Summary
- send welcome emails through new `sendWelcome` helper with localStorage-based idempotency key
- invoke helper after Google popup or redirect flows in signup and login pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, etc.)
- `npm run build` (fails: Missing Firebase env: apiKey)


------
https://chatgpt.com/codex/tasks/task_e_68a753360ee48324a3463d56985775ff