### PR TITLE
docs: clarify font usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Fonts
+
+The project does not use [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) or the Geist font. Typography is handled with standard CSS and Tailwind utilities. Some pages reference fonts like "Playfair Display" or "Poppins"; include these via `<link>` tags or other methods if you want them to render consistently.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- remove outdated reference to `next/font` and Geist
- document current font approach relying on standard CSS and optional fonts such as Playfair Display and Poppins

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a757cfb7ec8324bd555dc08b7dee8d